### PR TITLE
Revert to cluster over child_process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,28 +1,32 @@
 {
   "version": "0.2.0",
-  "configurations": [{
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach"
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Debug Project",
-      // we test in `build` to make cleanup fast and easy
-      "cwd": "${workspaceFolder}/dist",
+      // we test in `dist` to make cleanup fast and easy
+      "cwd": "${workspaceFolder}",
       // Replace this with your project root. If there are multiple, you can
       // automatically run the currently visible file with: "program": ${file}"
-      "program": "${workspaceFolder}/src/cli/cli.ts",
-      // "args": ["--no-install"],
+      "program": "${workspaceFolder}/demos/intro.js",
       "outFiles": ["${workspaceFolder}/dist/main/**/*.js"],
       "skipFiles": [
         "<node_internals>/**/*.js",
         "${workspaceFolder}/node_modules/**/*.js"
       ],
       "preLaunchTask": "npm: build",
-      "stopOnEntry": true,
+      "stopOnEntry": false,
       "smartStep": true,
+      "autoAttachChildProcesses": true,
       "runtimeArgs": ["--nolazy"],
-      "env": {
-        "TYPESCRIPT_STARTER_REPO_URL": "${workspaceFolder}"
-      },
-      "console": "externalTerminal"
+      "outputCapture": "std",
+      "console": "internalConsole"
     },
     {
       "type": "node",

--- a/demos/intro.js
+++ b/demos/intro.js
@@ -2,7 +2,7 @@ const { DynamicTerminal } = require("../dist/main/index.js");
 const chalk = require("chalk");
 const figures = require('figures');
 
-const tt = new DynamicTerminal();
+const dt = new DynamicTerminal();
 
 const lines = [];
 
@@ -14,7 +14,7 @@ async function sleep(milliseconds) {
   try {
 
     process.stdout.write('\033c'); // Clear the screen
-    tt.start({ repaintOnResize: true });
+    dt.start({ repaintOnResize: true });
 
     for (let i=0; i<=6; i++)
       lines.push({ text: '', indent: '' });
@@ -84,7 +84,7 @@ async function sleep(milliseconds) {
     lines[3] = { text: chalk.green(DynamicTerminal.TICK) + " I didn't even need to do anything", indent: 4 };
     update();
     lines[4].indent = 4;
-    await progressBar(lines[4]).catch((err) => { tt.stop(); setTimeout( () => console.error(err), 2000); });
+    await progressBar(lines[4]).catch((err) => { dt.stop(); setTimeout( () => console.error(err), 2000); });
 
     lines[1] = { text: chalk.red(DynamicTerminal.CROSS) + " Damn. I didn't find any!", indent: 4 };
     update();
@@ -121,24 +121,24 @@ async function sleep(milliseconds) {
     await sleep(400);
 
 
-    await tt.update([{ text: `${chalk.green(figures.tick)} I'm done showing off.`, indent: 2 }, { text: "Let's see what you can do!", indent: 4 }]);
+    await dt.update([{ text: `${chalk.green(figures.tick)} I'm done showing off.`, indent: 2 }, { text: "Let's see what you can do!", indent: 4 }]);
     await sleep(500);
-    await tt.stop();
+    await dt.stop();
     await sleep(500);
-    tt.destroy();
+    dt.destroy();
 
   } catch (err) {
-    tt.stop();
+    dt.stop();
     console.error('Error in demo:');
     console.error(err);
-    tt.destroy();
+    dt.destroy();
     process.exit();
   }
 })();
 
 
 function update() {
-  tt.update(lines);
+  dt.update(lines);
 }
 
 function typeWriter(line, text, interval = 20) {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,11 @@
     "analyzeCommits": {
       "preset": "angular",
       "releaseRules": [
-        { "type": "docs", "scope": "readme", "release": "patch" }
+        {
+          "type": "docs",
+          "scope": "readme",
+          "release": "patch"
+        }
       ]
     }
   }

--- a/src/DynamicTerminal.ts
+++ b/src/DynamicTerminal.ts
@@ -52,7 +52,7 @@ export class DynamicTerminal {
       return false;
     }
     const response = await this.send({ cmd: "START", options });
-    if (response.status === "started") {
+    if (response && response.status === "started") {
       return true;
     }
     return false;
@@ -75,7 +75,7 @@ export class DynamicTerminal {
       return false;
     }
     const response = await this.send({ cmd: "STOP", commit });
-    if (response.status === "stopped") {
+    if (response && response.status === "stopped") {
       return true;
     }
     return false;
@@ -109,7 +109,7 @@ export class DynamicTerminal {
       return false;
     }
     const response = await this.send({ cmd: "UPDATE", text });
-    if (response.status === "updated") {
+    if (response && response.status === "updated") {
       return true;
     }
     return false;
@@ -130,7 +130,7 @@ export class DynamicTerminal {
       return false;
     }
     const response = await this.send({ cmd: "APPEND", text });
-    if (response.status === "appended") {
+    if (response && response.status === "appended") {
       return true;
     }
     return false;
@@ -150,7 +150,7 @@ export class DynamicTerminal {
       return false;
     }
     const response = await this.send({ cmd: "RENDER", force });
-    if (response.status === "rendered") {
+    if (response && response.status === "rendered") {
       return true;
     }
     return false;
@@ -167,7 +167,7 @@ export class DynamicTerminal {
       return [];
     }
     const response = await this.send({ cmd: "RENDER_QUEUE" });
-    if (response.status === "rendered") {
+    if (response && response.status === "rendered") {
       return response.data;
     }
     return [];
@@ -179,7 +179,7 @@ export class DynamicTerminal {
     return new Promise(resolve => {
       const id = uuid();
 
-      let timeoutTimer;
+      let timeoutTimer: NodeJS.Timeout;
 
       const handler = msg => {
         if (msg.uuid === id) {

--- a/src/DynamicTerminalThread.ts
+++ b/src/DynamicTerminalThread.ts
@@ -119,7 +119,7 @@ class DynamicTerminalThread {
         ...options
       };
       this.wasRaw = process.stdin.isRaw;
-      if (options.disableInput) {
+      if (options.disableInput && process.stdout.isTTY) {
         process.stdin.setRawMode(true);
       }
 
@@ -170,7 +170,7 @@ class DynamicTerminalThread {
         process.stdout.write(ansi.eraseDown);
       }
 
-      if (this.wasRaw !== null) {
+      if (this.wasRaw !== null && process.stdout.isTTY) {
         process.stdin.setRawMode(this.wasRaw);
       }
       this.wasRaw = null;


### PR DESCRIPTION
Introduces several bug fixes.

The major change is reverting to using `cluster`, which handles process forking more gracefully than `child_process`.

When inspecting Node.js with `--inspect`, the parent would bind to a debug port. When forking with `child_process`, the child would attempt to inherit the same arguments and bind to the same port, causing a silent fork failure.

The first fix was to detect debugging and bind to a free OS port, this works, however, the child_process has no discovery in debug applications such as VS code.

VS Code has a relatively new `autoAttachChildProcesses` option that can automatically attach to child processes spawned *using the `cluster` module*. While I despise the usage of a global cluster module, which means that the worker is visible to the entire application, it provides sugar-coating around a lot of the various fork variables and arguments and plays better with VS Code.